### PR TITLE
fix: Comment out conditional rendering for project type in home group…

### DIFF
--- a/src/app/users/home/home-group/home-group.component.html
+++ b/src/app/users/home/home-group/home-group.component.html
@@ -165,7 +165,7 @@
 
   <!-- Navigation buttons -->
   <div class="grid grid-cols-2 gap-4 mx-10 mt-6">
-    @if (typeOfProjet() === "GROUP") {
+    <!-- @if (typeOfProjet() === "GROUP") {
     <a
       routerLink="membership"
       [queryParams]="{ typeOfProjet: typeOfProjet() }"
@@ -178,7 +178,7 @@
         name="lucideChevronRight"
       />
     </a>
-    }
+    } -->
     <!-- @if (typeOfProjet() === "GROUP") {
     <a
       routerLink="diary"


### PR DESCRIPTION
… component

- Temporarily disabled the conditional rendering logic for the "GROUP" project type in the home group component's HTML template.
- This change is intended for debugging purposes and may be revisited in future updates.