### PR TITLE
fix: Update account balance display in HomeComponent

### DIFF
--- a/src/app/users/home/home.component.html
+++ b/src/app/users/home/home.component.html
@@ -22,7 +22,7 @@
               <p class="font-bold">Solde compte Crélan</p>
               <p class="font-bold text-[9px]">000001</p>
             </div>
-            <p>100 000€</p>
+            <p>150 816,52€</p>
           </button>
         </div>
       </hlm-accordion-content>
@@ -201,7 +201,7 @@
             <p class="font-bold">Solde compte Crélan</p>
             <p class="font-bold text-[9px]">000001</p>
           </div>
-          <p>100 000€</p>
+          <p>150 816,52€</p>
         </button>
         <app-account-component
           class="w-1/3"


### PR DESCRIPTION
- Changed the displayed account balance from "100 000€" to "150 816,52€" in both the main and secondary sections of the HomeComponent.
- Ensured consistency in the account balance representation across the user interface.