### PR TITLE
feat: Add 'Mark as Paid' functionality in SEPA validation

### DIFF
--- a/src/app/admin/sepa-validation/sepa-validation.component.html
+++ b/src/app/admin/sepa-validation/sepa-validation.component.html
@@ -278,6 +278,14 @@
               </p>
             </div>
             <div class="flex gap-1">
+              <button
+                (click)="paidVirement(virement.id)"
+                class="inline-flex items-center justify-center text-white bg-green-600 rounded-lg hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500"
+                hlmBtn
+                [title]="'Marquer comme payé'"
+              >
+                <hlm-icon name="lucideCheckCircle2" class="w-4 h-4" size="sm" />
+              </button>
               <a
                 [href]="virement.invoice_url"
                 target="_blank"

--- a/src/app/admin/sepa-validation/sepa-validation.component.ts
+++ b/src/app/admin/sepa-validation/sepa-validation.component.ts
@@ -164,6 +164,14 @@ export class SepaValidationComponent implements AfterViewInit {
     });
   }
 
+  paidVirement(id: number) {
+    this.virementSepaService.paidVirement(id).subscribe(() => {
+      this.virementsSepaAccepted.update((virements) => {
+        return [...virements.filter((virement) => virement.id !== id)];
+      });
+    });
+  }
+
   protected openDetailedView(virement: VirementSepaEntity) {
     const index = this.virementsSepaInPending().findIndex(
       (v) => v.id === virement.id

--- a/src/app/shared/services/virement-sepa.service.ts
+++ b/src/app/shared/services/virement-sepa.service.ts
@@ -62,4 +62,11 @@ export class VirementSepaService {
       }
     );
   }
+
+  paidVirement(id: number) {
+    return this.httpClient.patch(
+      `${environment.API_URL}/virement-sepa/${id}/paid`,
+      {}
+    );
+  }
 }


### PR DESCRIPTION
- Implemented a new button in the SEPA validation component to mark a virement as paid.
- Added the `paidVirement` method in the SEPA validation component to handle the button click and update the state accordingly.
- Created a corresponding `paidVirement` method in the VirementSepaService to make an API call for marking the virement as paid.
- Enhanced the user interface by providing immediate feedback upon marking a virement as paid, improving overall user experience.